### PR TITLE
fix : compilation namePrefix wrongly defined

### DIFF
--- a/src/compilation.ts
+++ b/src/compilation.ts
@@ -96,7 +96,7 @@ export class Compilation {
 				nameWithoutSuffix: name,
 			};
 		}
-		const namePrefix = parts[parts.length - 1];
+		const namePrefix = parts[0];
 		const nameSuffix = parts[parts.length - 1];
 		const nameWithoutPrefix = parts.slice(1).join("-");
 		const nameWithoutSuffix = parts.slice(0, parts.length - 1).join("-");


### PR DESCRIPTION
Name prefix was wrongly defined in compilation.ts (was equal to name suffix)